### PR TITLE
show approved students in tutor session review modal

### DIFF
--- a/src/dash/tutor_view/SessionReviewModal.jsx
+++ b/src/dash/tutor_view/SessionReviewModal.jsx
@@ -169,8 +169,6 @@ class SessionModal extends React.Component {
                 if (response.data.success) {
                     console.log(response.data);
                     updateSession(
-                        response.data.session.hangouts_link,
-                        response.data.session.eventId,
                         response.data.session
                     );
                     socket.emit('tutor-approve', {
@@ -213,8 +211,6 @@ class SessionModal extends React.Component {
                     if (response.data.success) {
                         console.log(response.data);
                         updateSession(
-                            response.data.session.hangouts_link,
-                            response.data.session.eventId,
                             response.data.session
                         );
                         socket.emit('tutor-deny', {
@@ -265,7 +261,7 @@ class SessionModal extends React.Component {
             </div>
         ));
         const renRequests = (session.join_requests || [])
-            .filter(student => student.status === 'pending')
+            .filter(student => student.status === 'pending' || student.status === 'approved')
             .map((student) => (
                 <div className="student-join-request col-sm-12">
                     <h5 className="col-sm-3">{student.student_id}</h5>
@@ -279,14 +275,20 @@ class SessionModal extends React.Component {
                             ? student.student_comment
                             : 'No Request Description'}
                     </h5>
-                    <span
-                        onClick={() => this.approveStudent(student)}
-                        className="col-sm-1 glyphicon glyphicon-ok approve-student"
-                    />
-                    <span
-                        onClick={() => this.denyStudent(student)}
-                        className="col-sm-1 glyphicon glyphicon-remove deny-student"
-                    />
+                    {
+                        student.status === 'pending' ?
+                            <div>
+                                <span
+                                    onClick={() => this.approveStudent(student)}
+                                    className="col-sm-1 glyphicon glyphicon-ok approve-student"
+                                />
+                                <span
+                                    onClick={() => this.denyStudent(student)}
+                                    className="col-sm-1 glyphicon glyphicon-remove deny-student"
+                                />
+                            </div> : <div><h5 className="approve-student">approved</h5></div>
+                    }
+
                 </div>
             ));
         return (

--- a/src/dash/tutor_view/TutorUpcomingEvent.jsx
+++ b/src/dash/tutor_view/TutorUpcomingEvent.jsx
@@ -31,6 +31,7 @@ class TutorUpcomingEvent extends React.Component {
         this.updateSession = this.updateSession.bind(this);
         this.initUpcomingEvent = this.initUpcomingEvent.bind(this);
         this.onUnload = this.onUnload.bind(this);
+        this.setNewState = this.setNewState.bind(this);
     }
 
     /**
@@ -56,6 +57,7 @@ class TutorUpcomingEvent extends React.Component {
         // window.removeEventListener("beforeunload", this.onUnload);
     }
 
+
     /**
      * Check for an open session on unload
      * TODO: figure out how to get this to work
@@ -68,6 +70,10 @@ class TutorUpcomingEvent extends React.Component {
             e.returnValue = 'oh no open session';
             return 'oh no open session';
         }
+    }
+
+    setNewState(session) {
+        this.setState({session});
     }
 
     /**


### PR DESCRIPTION
In order to make it less confusing, keep approved join requests in the session review modal. That way, the tutor can know which students could potentially join the session